### PR TITLE
[METRICS-1487] (refactor) use url attribute of the resource.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+signalform-tools (0.0.14) lucid; urgency=low
+
+  * Show command now uses the resource url attribute
+
+ -- Rahul Ravindran <rahulrav@yelp.com>  Thu, 26 Oct 2017 11:01:59 -0700
+
 signalform-tools (0.0.13) lucid; urgency=low
 
   * Renamed build variable PYPI_URL to CUSTOM_PYPI_URL

--- a/signalform_tools/__about__.py
+++ b/signalform_tools/__about__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf8 -*-
 
-__version_info__ = (0, 0, 13)
+__version_info__ = (0, 0, 14)
 __version__ = '%d.%d.%d' % __version_info__

--- a/signalform_tools/show.py
+++ b/signalform_tools/show.py
@@ -24,10 +24,7 @@ def show(resource):
         res_type = TYPE_MAPPING[resource['type']]
         print(res_type)
         print(resource['primary']['attributes']['name'])
-        url = SIGNALFX_API + res_type + '/' + resource['primary']['attributes']['id']
-        if res_type == 'detector':
-            url += '/edit'
-        print(url + '\n')
+        print(resource['primary']['attributes']['url'] + '\n')
     except KeyError:
         pass
 


### PR DESCRIPTION
**Summary**
[tf-provider-signalform](https://github.com/Yelp/terraform-provider-signalform/blob/3f1ef7b9985d0f23e2c96491a05dca623ec4f7e3/src/terraform-provider-signalform/signalform/dashboard.go#L35) already has url as an attribute for the resource. Use that instead of computing the url always as it is redundant.