### PR TITLE
Fix failing build by freezing ffi dependency

### DIFF
--- a/pkg/dockerfiles/trusty/Dockerfile
+++ b/pkg/dockerfiles/trusty/Dockerfile
@@ -44,6 +44,7 @@ RUN cd /tmp && \
 
 RUN pip install virtualenv==15.1.0
 
+RUN gem install ffi --no-rdoc --no-ri -v 1.9.18
 RUN gem install fpm
 
 WORKDIR /work

--- a/pkg/dockerfiles/xenial/Dockerfile
+++ b/pkg/dockerfiles/xenial/Dockerfile
@@ -43,6 +43,7 @@ RUN cd /tmp && \
     gdebi -n dh-virtualenv*.deb && \
     rm dh-virtualenv_*.deb
 
+RUN gem install ffi --no-rdoc --no-ri -v 1.9.18
 RUN gem install fpm
 
 WORKDIR /work


### PR DESCRIPTION
**Summary**
gem fpm is failing because of the dependency on ffi. Freeze ffi version
to the last stable version used.