### PR TITLE
Add another way to send program_text to signalform-tools preflight

### DIFF
--- a/signalform_tools/preflight.py
+++ b/signalform_tools/preflight.py
@@ -57,6 +57,8 @@ def extract_program_text(filename: str) -> List[str]:
                 if pattern.match(resource) is not None:
                     program_text.append(resources[resource]['primary']['attributes']['program_text'])
             return program_text
+        elif filename.endswith('.preflight'):
+            return [conf.read()]
         else:
             configs = conf.read()
             pattern = re.compile(r'program_text:.+(?:=>)?\s+\"(.+)\"')


### PR DESCRIPTION
This way we can generate a program to test without applying terraform. Parsing tf_plan is not always supported when there is some binary output.

See internal ticket PEOBS-569, slo_transcoder will be using this method of sending program text to preflight.