### PR TITLE
Drop lucid add bionic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,10 @@ services:
     - docker
 install:
     - pip install tox
+env:
+    - TARGET=test
+    - TARGET=itest_trusty
+    - TARGET=itest_xenial
+    - TARGET=itest_bionic
 script:
-    - make
+    - make $TARGET

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ ifdef CUSTOM_PYPI_URL
 TOX_PYPI_URL=-i $(CUSTOM_PYPI_URL)
 endif
 
-all: test itest_trusty itest_xenial
+all: test itest_trusty itest_xenial itest_bionic
 
 changelog:
 	if [ ! -f debian/changelog ]; then \
@@ -31,7 +31,7 @@ dist:
 itest_%: dist
 	make -C pkg $@
 
-package: itest_trusty itest_xenial
+package: itest_trusty itest_xenial itest_bionic
 
 tag:
 	git tag v${PACKAGE_VERSION}

--- a/pkg/dockerfiles/bionic/Dockerfile
+++ b/pkg/dockerfiles/bionic/Dockerfile
@@ -7,18 +7,12 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-rec
         dpkg-dev \
         equivs \
         gdebi-core \
-        git \
         libcurl4-openssl-dev \
         libyaml-dev \
-        python-dev \
         python3-dev \
         python-pip \
         python-pkg-resources \
         python-setuptools \
-        rpm \
-        ruby \
-        ruby-dev \
-        software-properties-common \
         wget \
     && apt-get clean
 
@@ -26,8 +20,5 @@ RUN cd /tmp && \
     wget http://mirrors.kernel.org/ubuntu/pool/universe/d/dh-virtualenv/dh-virtualenv_1.0-1_all.deb && \
     gdebi -n dh-virtualenv*.deb && \
     rm dh-virtualenv_*.deb
-
-RUN gem install ffi --no-rdoc --no-ri -v 1.9.18
-RUN gem install fpm
 
 WORKDIR /work

--- a/pkg/dockerfiles/bionic/Dockerfile
+++ b/pkg/dockerfiles/bionic/Dockerfile
@@ -1,9 +1,4 @@
-FROM ubuntu:xenial
-
-# Need Python 3.6
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    software-properties-common
-RUN add-apt-repository ppa:deadsnakes/ppa
+FROM ubuntu:bionic
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install \
         build-essential \
@@ -16,13 +11,14 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-rec
         libcurl4-openssl-dev \
         libyaml-dev \
         python-dev \
-        python3.6-dev \
+        python3-dev \
         python-pip \
         python-pkg-resources \
         python-setuptools \
         rpm \
         ruby \
         ruby-dev \
+        software-properties-common \
         wget \
     && apt-get clean
 

--- a/pkg/dockerfiles/itest/bionic/Dockerfile
+++ b/pkg/dockerfiles/itest/bionic/Dockerfile
@@ -1,11 +1,8 @@
-FROM ubuntu:trusty
+FROM ubuntu:bionic
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gdebi-core \
-    software-properties-common \
+    xz-utils \
     && apt-get clean
-
-# Need Python 3.6
-RUN add-apt-repository ppa:deadsnakes/ppa
 
 WORKDIR /work

--- a/pkg/dockerfiles/itest/lucid/Dockerfile
+++ b/pkg/dockerfiles/itest/lucid/Dockerfile
@@ -1,3 +1,0 @@
-FROM    docker-dev.yelpcorp.com/lucid_yelp
-
-WORKDIR /work

--- a/pkg/dockerfiles/itest/xenial/Dockerfile
+++ b/pkg/dockerfiles/itest/xenial/Dockerfile
@@ -1,20 +1,11 @@
 FROM ubuntu:xenial
 
-RUN apt-get update > /dev/null && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install \
-        bash \
-        curl \
-        vim-tiny \
-        less \
-        locales > /dev/null \
-    && DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade > /dev/null \
-    && apt-get clean > /dev/null
-
-RUN /usr/sbin/locale-gen en_US.UTF-8
-ENV LANG en_US.UTF-8
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gdebi-core \
+    software-properties-common \
+    && apt-get clean
 
 # Need Python 3.6
-RUN apt-get update > /dev/null && \
-    apt-get install -y --no-install-recommends software-properties-common && \
-    add-apt-repository ppa:deadsnakes/ppa
+RUN add-apt-repository ppa:deadsnakes/ppa
 
 WORKDIR /work

--- a/pkg/dockerfiles/lucid/Dockerfile
+++ b/pkg/dockerfiles/lucid/Dockerfile
@@ -1,6 +1,0 @@
-FROM    docker-dev.yelpcorp.com/lucid_pkgbuild
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        python3.6 && \
-    apt-get clean
-WORKDIR /work

--- a/pkg/dockerfiles/trusty/Dockerfile
+++ b/pkg/dockerfiles/trusty/Dockerfile
@@ -1,22 +1,11 @@
 FROM ubuntu:trusty
 
-RUN apt-get update > /dev/null && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install \
-        bash \
-        curl \
-        vim-tiny \
-        less > /dev/null \
-    && DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade > /dev/null \
-    && apt-get clean > /dev/null
-
-RUN /usr/sbin/locale-gen en_US.UTF-8
-ENV LANG en_US.UTF-8
-
 # Need Python 3.6
-RUN apt-get update > /dev/null && \
-    apt-get install -y --no-install-recommends software-properties-common && \
-    add-apt-repository ppa:deadsnakes/ppa
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    software-properties-common
+RUN add-apt-repository ppa:deadsnakes/ppa
 
-RUN apt-get update > /dev/null && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install \
         build-essential \
         debhelper \
         devscripts \
@@ -34,8 +23,8 @@ RUN apt-get update > /dev/null && DEBIAN_FRONTEND=noninteractive apt-get -y --no
         rpm \
         ruby \
         ruby-dev \
-        wget > /dev/null \
-    && apt-get clean > /dev/null
+        wget \
+    && apt-get clean
 
 RUN cd /tmp && \
     wget http://mirrors.kernel.org/ubuntu/pool/universe/d/dh-virtualenv/dh-virtualenv_1.0-1_all.deb && \

--- a/pkg/dockerfiles/trusty/Dockerfile
+++ b/pkg/dockerfiles/trusty/Dockerfile
@@ -12,17 +12,12 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-rec
         dpkg-dev \
         equivs \
         gdebi-core \
-        git \
         libcurl4-openssl-dev \
         libyaml-dev \
-        python-dev \
         python3.6-dev \
         python-pip \
         python-pkg-resources \
         python-setuptools \
-        rpm \
-        ruby \
-        ruby-dev \
         wget \
     && apt-get clean
 
@@ -32,8 +27,5 @@ RUN cd /tmp && \
     rm dh-virtualenv_*.deb
 
 RUN pip install virtualenv==15.1.0
-
-RUN gem install ffi --no-rdoc --no-ri -v 1.9.18
-RUN gem install fpm
 
 WORKDIR /work

--- a/pkg/dockerfiles/xenial/Dockerfile
+++ b/pkg/dockerfiles/xenial/Dockerfile
@@ -12,7 +12,6 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-rec
         dpkg-dev \
         equivs \
         gdebi-core \
-        git \
         libcurl4-openssl-dev \
         libyaml-dev \
         python-dev \
@@ -20,9 +19,6 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-rec
         python-pip \
         python-pkg-resources \
         python-setuptools \
-        rpm \
-        ruby \
-        ruby-dev \
         wget \
     && apt-get clean
 
@@ -30,8 +26,5 @@ RUN cd /tmp && \
     wget http://mirrors.kernel.org/ubuntu/pool/universe/d/dh-virtualenv/dh-virtualenv_1.0-1_all.deb && \
     gdebi -n dh-virtualenv*.deb && \
     rm dh-virtualenv_*.deb
-
-RUN gem install ffi --no-rdoc --no-ri -v 1.9.18
-RUN gem install fpm
 
 WORKDIR /work

--- a/pkg/itest/ubuntu.sh
+++ b/pkg/itest/ubuntu.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 cd /
 
 highlight() {
@@ -22,11 +24,13 @@ source /etc/lsb-release
 
 # This will set us up to install our package through apt-get
 highlight "Creating new apt source"
-echo "deb file:/dist/${DISTRIB_CODENAME} ./" | tee "/etc/apt/sources.list.d/itest-${PACKAGE_NAME}.list"
 
 highlight_exec apt-get update
 
 # The package should install ok
-highlight_exec apt-get install -y --force-yes "${PACKAGE_NAME}=${PACKAGE_VERSION}"
+highlight_exec gdebi -n /dist/${DISTRIB_CODENAME}/${PACKAGE_NAME}_${PACKAGE_VERSION}_amd64.deb
+
+
+${PACKAGE_NAME} --version
 
 highlight "$0:" 'success!'


### PR DESCRIPTION
Updates the dockerfiles and itests to build also for bionic and drops
the lucid files.
I also removed a bunch of useless (afaict) installs like vim-tiny and
curl. Similarly fpm was installed but then it's not used to build the
deb package so it's useless.

    make itest_trusty
    make itest_xenial
    make itest_bionic

all pass.

This might help the trusty itest on jenkins that seems to always 
struggle to install fpm.